### PR TITLE
feat: add "enabled commands" configuration

### DIFF
--- a/ffxivbot/config_example.json
+++ b/ffxivbot/config_example.json
@@ -1,4 +1,6 @@
 {
+  "ENABLED_COMMANDS": ["cat", "gakki", "10", "bird", "comment", "search", "about", "donate", "anime", "gate", "chp", "random", "weather", "gif", "dps", "dice", "hso", "raid", "bot", "pixiv", "duilian", "image", "nuannuan", "tex", "waifu", "quest", "share", "trash", "shorten", "ifttt", "fsx", "treasure", "hh", "luck", "abv", "market", "akhr"],
+  "ENABLED_GROUP_COMMANDS": ["group", "welcome", "custom", "repeat", "repeat", "left", "ban", "revenge", "vote", "weibo", "live", "lottery", "command", "hunt"],
   "QQ_BASE_URL": "http://111.231.102.248/",
   "WEB_BASE_URL": "https://xn--v9x.net/",
   "ACCESS_TOKEN": "",


### PR DESCRIPTION
As we all know, this project has MANY confusing features unrelated to FFXIV (such as `/akhr` and `/hso`) or with unknown use (such as `/10` and `/chp`). I can only disable it after deployment in QQ with group creator privilege. And, if I have multiple groups I have to disable for each group.

I added two configuration items to `config.json`: `ENABLED_COMMANDS` and `ENABLED_GROUP_COMMANDS`. By default they includes ALL commands in the project. If they're modified the corresponding command will be disabled for ALL groups and hidden in the `/help` command.

For backward compatibility, a earlier-created configuration file with no such properties will enable ALL commands.