### PR TITLE
Send the message of /help in pieces & ...

### DIFF
--- a/ffxivbot/event_handler.py
+++ b/ffxivbot/event_handler.py
@@ -166,7 +166,8 @@ class EventHandler(object):
                                 break
         # Handle /help
         if receive["message"].startswith("/help"):
-            msg = ""
+            msg = '帮助:\n'
+            msgLineCount = 0
             for (k, v) in handlers.commands.items():
                 command_enable = True  # always True for private
                 if group and group_commands:
@@ -175,6 +176,20 @@ class EventHandler(object):
                     )  # hide if disabled in group
                 if command_enable:
                     msg += "{}: {}\n".format(k, v)
+                    msgLineCount = msgLineCount + 1
+                    if msgLineCount == 22:
+                        msg = msg.strip()
+                        self.api_caller.send_message(
+                            receive["message_type"],
+                            group_id or user_id,
+                            msg,
+                            post_type=receive.get("reply_api_type", "websocket"),
+                            chatId=receive.get("chatId", ""),
+                            channel_id=receive.get("channel_id", ""),
+                            nonce=receive.get("nonce", ""),
+                        )
+                        msg = '帮助:\n'
+                        msgLineCount = 0
             msg += "具体介绍详见Wiki使用手册: {}\n".format(
                 "https://github.com/Bluefissure/OtterBot/wiki"
             )

--- a/ffxivbot/event_handler.py
+++ b/ffxivbot/event_handler.py
@@ -166,7 +166,7 @@ class EventHandler(object):
                                 break
         # Handle /help
         if receive["message"].startswith("/help"):
-            msg = "帮助:\n"
+            msg = "[第 1 页]\n"
             msgLineCount = 0
             for (k, v) in handlers.commands.items():
                 command_enable = True  # always True for private
@@ -177,7 +177,7 @@ class EventHandler(object):
                 if command_enable:
                     msg += "{}: {}\n".format(k, v)
                     msgLineCount = msgLineCount + 1
-                    if msgLineCount == 20:
+                    if msgLineCount % 20 == 0:
                         msg = msg.strip()
                         self.api_caller.send_message(
                             receive["message_type"],
@@ -188,8 +188,7 @@ class EventHandler(object):
                             channel_id=receive.get("channel_id", ""),
                             nonce=receive.get("nonce", ""),
                         )
-                        msg = "帮助:\n"
-                        msgLineCount = 0
+                        msg = "[第 {} 页]\n".format(int(msgLineCount / 20 + 1))
             msg += "具体介绍详见Wiki使用手册: {}\n".format(
                 "https://github.com/Bluefissure/OtterBot/wiki"
             )

--- a/ffxivbot/event_handler.py
+++ b/ffxivbot/event_handler.py
@@ -166,7 +166,7 @@ class EventHandler(object):
                                 break
         # Handle /help
         if receive["message"].startswith("/help"):
-            msg = '帮助:\n'
+            msg = "帮助:\n"
             msgLineCount = 0
             for (k, v) in handlers.commands.items():
                 command_enable = True  # always True for private
@@ -188,7 +188,7 @@ class EventHandler(object):
                             channel_id=receive.get("channel_id", ""),
                             nonce=receive.get("nonce", ""),
                         )
-                        msg = '帮助:\n'
+                        msg = "帮助:\n"
                         msgLineCount = 0
             msg += "具体介绍详见Wiki使用手册: {}\n".format(
                 "https://github.com/Bluefissure/OtterBot/wiki"

--- a/ffxivbot/event_handler.py
+++ b/ffxivbot/event_handler.py
@@ -177,7 +177,7 @@ class EventHandler(object):
                 if command_enable:
                     msg += "{}: {}\n".format(k, v)
                     msgLineCount = msgLineCount + 1
-                    if msgLineCount == 22:
+                    if msgLineCount == 20:
                         msg = msg.strip()
                         self.api_caller.send_message(
                             receive["message_type"],


### PR DESCRIPTION
1. Since Mirai does not support long messages in private chat, divided the output of /help into fragments to support /help in private chat.
2. add `第 {} 页` in the top of each help fraction to avoid bots triggering each other while sending /help.