### PR TITLE
ci: add cache for pip

### DIFF
--- a/.github/workflows/python-3.6.yml
+++ b/.github/workflows/python-3.6.yml
@@ -30,9 +30,27 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.6
-    - name: Install dependencies
+    - name: Upgrade pip
       run: |
         python -m pip install --upgrade pip
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: pip cache
+      id: cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Test


### PR DESCRIPTION
In the workflow, the step installing pip dependencies spend the longest time,
so for now just cache pip.

(It's definitely not that I don't know how to do other work.`(/▽＼)`）

EDIT: WOW I reached the 100th Pull Request achievement!